### PR TITLE
Issue 2 missing links

### DIFF
--- a/gogoanime.py
+++ b/gogoanime.py
@@ -244,4 +244,5 @@ os.makedirs(folder, exist_ok=True)
 with open(links_file, 'a') as f:
     f.write('\n'.join([ f'{link}\n    out={name}\n    referer={episode}'
         for name,link,episode in episodes['mp4']]))
+    f.write('\n')
     print(f"Links written to:\n   {links_file}")

--- a/gogoanime.py
+++ b/gogoanime.py
@@ -212,9 +212,9 @@ for n,episode in episodes['vidstream']:
         print(f'Page written to {debug_html} for debugging.')
         sys.exit(2)
     # sort according to resolution text
-    link_maxres = sorted(links_episodes,
+    link_maxres = max(links_episodes,
             key=(lambda l: int(re.search(r"([0-9]+)P", l.text).group(1)))
-            )[0]
+            )
     link = link_maxres.find('a').get('href')
     print(f"Link found for episode:\n\tEpisode: {episode}\n\tLink: {link}")
     print(f"\tList of links found:")

--- a/gogoanime.py
+++ b/gogoanime.py
@@ -213,7 +213,7 @@ for n,episode in episodes['vidstream']:
         sys.exit(2)
     # sort according to resolution text
     link_maxres = sorted(links_episodes,
-            key=(lambda l: re.search(r"([0-9]+)P", l.text).group(1))
+            key=(lambda l: int(re.search(r"([0-9]+)P", l.text).group(1)))
             )[0]
     link = link_maxres.find('a').get('href')
     print(f"Link found for episode:\n\tEpisode: {episode}\n\tLink: {link}")

--- a/gogoanime.py
+++ b/gogoanime.py
@@ -216,13 +216,6 @@ for n,episode in episodes['vidstream']:
             key=(lambda l: int(re.search(r"([0-9]+)P", l.text).group(1)))
             )
     link = link_maxres.find('a').get('href')
-    print(f"Link found for episode:\n\tEpisode: {episode}\n\tLink: {link}")
-    print(f"\tList of links found:")
-    for l in links:
-        print(f"\t\t{l}")
-    print(f"\tList of episode links found:")
-    for l in links_episodes:
-        print(f"\t\t{l}")
     resolution = re.search(r"[0-9]+P", link_maxres.text).group()
     name = f"{n}_{resolution}.mp4"
     episodes['mp4'].append((name,link,episode))
@@ -232,10 +225,6 @@ browser.quit()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #                              Write links to file
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-print("=== === === === ===")
-for name,link,episode in episodes['mp4']:
-    print(f"Entry to be added:\n\tName: {name}\n\tReferer: {episode}\n\tLink: {link}")
 
 # Create download directory (if non-existant) ----------------------------------
 os.makedirs(folder, exist_ok=True)

--- a/gogoanime.py
+++ b/gogoanime.py
@@ -216,6 +216,13 @@ for n,episode in episodes['vidstream']:
             key=(lambda l: re.search(r"([0-9]+)P", l.text).group(1))
             )[0]
     link = link_maxres.find('a').get('href')
+    print(f"Link found for episode:\n\tEpisode: {episode}\n\tLink: {link}")
+    print(f"\tList of links found:")
+    for l in links:
+        print(f"\t\t{l}")
+    print(f"\tList of episode links found:")
+    for l in links_episodes:
+        print(f"\t\t{l}")
     resolution = re.search(r"[0-9]+P", link_maxres.text).group()
     name = f"{n}_{resolution}.mp4"
     episodes['mp4'].append((name,link,episode))
@@ -225,6 +232,10 @@ browser.quit()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #                              Write links to file
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+print("=== === === === ===")
+for name,link,episode in episodes['mp4']:
+    print(f"Entry to be added:\n\tName: {name}\n\tReferer: {episode}\n\tLink: {link}")
 
 # Create download directory (if non-existant) ----------------------------------
 os.makedirs(folder, exist_ok=True)


### PR DESCRIPTION
Fixed issue where new episode links would not appear.

Cause for issue: File was not newline terminated, causing the link of the new episode to not be added in its own line.

Fix: Add newline at the end of the file, after writing all the links.

---

Also fix a bug where highest resolution is not always picked.